### PR TITLE
Add Circle unit tests, added to .pyi and other

### DIFF
--- a/geometry.pyi
+++ b/geometry.pyi
@@ -12,7 +12,7 @@ from typing import (
 from typing_extensions import Literal as Literal
 from typing_extensions import Protocol
 
-from pygame.math import Vector2
+from pygame.math import Vector2, Vector3
 from pygame.rect import Rect
 
 
@@ -87,3 +87,35 @@ class Line:
     def raycast(self, x1: float, y1: float, x2: float, y2: float) -> Optional[Tuple[float, float]]: ...
     @overload
     def raycast(self, first: Sequence[float], second: Sequence[float]) -> Optional[Tuple[float, float]]: ...
+
+
+_CanBeCircle = Union[
+    Vector3,
+    "Circle",
+    Tuple[float, float, float],
+    Sequence[float]
+]
+class _HasCirclettribute(Protocol):
+    # An object that has a circle attribute that is either a circle, or a function
+    # that returns a circle
+    circle: Union[CircleValue, Callable[[], CircleValue]]
+
+CircleValue = Union[_CanBeCircle, _HasCirclettribute]
+
+
+class Circle:
+    x: float
+    y: float
+    r: float
+    r_sqr: float
+    __safe_for_unpickling__: Literal[True]
+    __hash__: None  # type: ignore
+
+    @overload
+    def __init__(self, circle: Circle) -> None: ...
+    @overload
+    def __init__(self, x: float, y: float, r: float) -> None: ...
+    @overload
+    def __init__(self, single_arg: CircleValue) -> None: ...
+    def __copy__(self) -> "Circle": ...
+    copy = __copy__

--- a/src_c/Include/circle.h
+++ b/src_c/Include/circle.h
@@ -3,12 +3,12 @@
 
 #include "pygame.h"
 
-typedef struct pgCircle {
+typedef struct pgCircleBase {
     double x, y, r, r_sqr;
-} pgCircle;
+} pgCircleBase;
 
 typedef struct pgCircleObject {
-    PyObject_HEAD pgCircle circle;
+    PyObject_HEAD pgCircleBase circle;
     PyObject *weakreflist;
 } pgCircleObject;
 

--- a/src_c/Include/collisions.h
+++ b/src_c/Include/collisions.h
@@ -10,8 +10,6 @@
 #include "line.h"
 #include "circle.h"
 
-typedef pgCircle pgCircleBase;
-
 static int
 pgCollision_LineLine(pgLineBase *, pgLineBase *);
 static int

--- a/src_c/circle.c
+++ b/src_c/circle.c
@@ -51,7 +51,7 @@ pg_circle_dealloc(pgCircleObject *self)
 }
 
 static int
-_pg_circle_set_radius(PyObject *value, pgCircle *circle)
+_pg_circle_set_radius(PyObject *value, pgCircleBase *circle)
 {
     double tmp = 0;
     if (!pg_DoubleFromObj(value, &tmp))
@@ -61,7 +61,7 @@ _pg_circle_set_radius(PyObject *value, pgCircle *circle)
     return 1;
 }
 static int
-pgCircle_FromObject(PyObject *obj, pgCircle *temp)
+pgCircle_FromObject(PyObject *obj, pgCircleBase *temp)
 {
     Py_ssize_t length;
 
@@ -89,7 +89,7 @@ pgCircle_FromObject(PyObject *obj, pgCircle *temp)
             return 1;
         }
         else {
-            /* Sequences of size other than 3 are not supported
+            /* Sequences of size other than 3 or 1 are not supported
             (don't wanna support infinite sequence nesting anymore)*/
             return 0;
         }
@@ -124,8 +124,17 @@ pgCircle_FromObject(PyObject *obj, pgCircle *temp)
 
             return 1;
         }
+        else if (length == 1) {
+            tmp = PySequence_ITEM(obj, 0);
+            if (!pgCircle_FromObject(tmp, temp)) {
+                Py_DECREF(tmp);
+                return 0;
+            }
+            Py_DECREF(tmp);
+            return 1;
+        }
         else {
-            /* Sequences of size other than 3 are not supported
+            /* Sequences of size other than 3 or 1 are not supported
             (don't wanna support infinite sequence nesting anymore)*/
             return 0;
         }
@@ -161,7 +170,7 @@ pgCircle_FromObject(PyObject *obj, pgCircle *temp)
 }
 
 static PyObject *
-pgCircle_New(pgCircle *c)
+pgCircle_New(pgCircleBase *c)
 {
     return _pg_circle_subtype_new3(&pgCircle_Type, c->x, c->y, c->r);
 }
@@ -214,7 +223,7 @@ pg_circle_str(pgCircleObject *self)
 static PyObject *
 pg_circle_richcompare(PyObject *o1, PyObject *o2, int opid)
 {
-    pgCircle o1_circ, o2_circ;
+    pgCircleBase o1_circ, o2_circ;
     double r1, r2;
 
     if (!pgCircle_FromObject(o1, &o1_circ) ||
@@ -260,6 +269,7 @@ pg_circle_richcompare(PyObject *o1, PyObject *o2, int opid)
             self->circle.name = val;                                          \
             return 0;                                                         \
         }                                                                     \
+        RAISE(PyExc_TypeError, "Expected a number");                          \
         return -1;                                                            \
     }
 
@@ -283,6 +293,7 @@ pg_circle_setr(pgCircleObject *self, PyObject *value, void *closure)
         self->circle.r_sqr = val * val;
         return 0;
     }
+    RAISE(PyExc_TypeError, "Expected a number");
     return -1;
 }
 

--- a/src_c/circle.c
+++ b/src_c/circle.c
@@ -54,7 +54,7 @@ static int
 _pg_circle_set_radius(PyObject *value, pgCircleBase *circle)
 {
     double tmp = 0;
-    if (!pg_DoubleFromObj(value, &tmp))
+    if (!pg_DoubleFromObj(value, &tmp) || tmp < 0)
         return 0;
     circle->r = tmp;
     circle->r_sqr = tmp * tmp;
@@ -287,14 +287,15 @@ pg_circle_setr(pgCircleObject *self, PyObject *value, void *closure)
 {
     double val;
     DEL_ATTR_NOT_SUPPORTED_CHECK_NO_NAME(value);
-    if (pg_DoubleFromObj(value, &val)) {
-        val = ABS(val);
-        self->circle.r = val;
-        self->circle.r_sqr = val * val;
-        return 0;
+
+    if (!pg_DoubleFromObj(value, &val) || val < 0) {
+        RAISE(PyExc_TypeError, "Expected a positive number");
+        return -1;
     }
-    RAISE(PyExc_TypeError, "Expected a number");
-    return -1;
+
+    self->circle.r = val;
+    self->circle.r_sqr = val * val;
+    return 0;
 }
 
 static PyObject *

--- a/src_c/circle.c
+++ b/src_c/circle.c
@@ -277,11 +277,14 @@ pg_circle_richcompare(PyObject *o1, PyObject *o2, int opid)
 GETSET_FOR_SIMPLE(x)
 GETSET_FOR_SIMPLE(y)
 
+#undef GETSET_FOR_SIMPLE
+
 static PyObject *
 pg_circle_getr(pgCircleObject *self, void *closure)
 {
     return PyFloat_FromDouble(self->circle.r);
 }
+
 static int
 pg_circle_setr(pgCircleObject *self, PyObject *value, void *closure)
 {
@@ -302,6 +305,22 @@ static PyObject *
 pg_circle_getr_sqr(pgCircleObject *self, void *closure)
 {
     return PyFloat_FromDouble(self->circle.r_sqr);
+}
+
+static int
+pg_circle_setr_sqr(pgCircleObject *self, PyObject *value, void *closure)
+{
+    double val;
+    DEL_ATTR_NOT_SUPPORTED_CHECK_NO_NAME(value);
+
+    if (!pg_DoubleFromObj(value, &val) || val < 0) {
+        RAISE(PyExc_TypeError, "Expected a positive number");
+        return -1;
+    }
+
+    self->circle.r_sqr = val;
+    self->circle.r = sqrt(val);
+    return 0;
 }
 
 static PyObject *
@@ -326,7 +345,8 @@ static PyGetSetDef pg_circle_getsets[] = {
     {"x", (getter)pg_circle_getx, (setter)pg_circle_setx, NULL, NULL},
     {"y", (getter)pg_circle_gety, (setter)pg_circle_sety, NULL, NULL},
     {"r", (getter)pg_circle_getr, (setter)pg_circle_setr, NULL, NULL},
-    {"r_sqr", (getter)pg_circle_getr_sqr, NULL, NULL, NULL},
+    {"r_sqr", (getter)pg_circle_getr_sqr, (setter)pg_circle_setr_sqr, NULL,
+     NULL},
     {"__safe_for_unpickling__", (getter)pg_circle_getsafepickle, NULL, NULL,
      NULL},
     {NULL, 0, NULL, NULL, NULL} /* Sentinel */

--- a/unittests/circle_test.py
+++ b/unittests/circle_test.py
@@ -22,7 +22,7 @@ class CircleTypeTest(unittest.TestCase):
             with self.assertRaises(TypeError):
                 c = Circle(0, value, 1)
         # Test r
-        for value in invalid_types:
+        for value in invalid_types + (-1, ):
             with self.assertRaises(TypeError):
                 c = Circle(0, 0, value)
 
@@ -156,7 +156,7 @@ class CircleTypeTest(unittest.TestCase):
         """Ensures the r attribute handles invalid values correctly."""
         c = Circle(0, 0, 1)
 
-        for value in (None, [], "1", (1,), [1, 2, 3]):
+        for value in (None, [], "1", (1,), [1, 2, 3], -1):
             with self.assertRaises(TypeError):
                 c.r = value
 
@@ -212,6 +212,13 @@ class CircleTypeTest(unittest.TestCase):
 
         # check c2 is not c
         self.assertIsNot(c_2, c)
+
+    def test_bool(self):
+        c = Circle(10, 10, 4)
+        c2 = Circle(10, 10, 0)
+
+        self.assertTrue(c, "Expected c to be True as radius is >= 0")
+        self.assertFalse(c2, "Expected c to be False as radius is < 0")
 
 
 if __name__ == "__main__":

--- a/unittests/circle_test.py
+++ b/unittests/circle_test.py
@@ -1,0 +1,218 @@
+import unittest
+
+from pygame import Vector2
+
+from geometry import Circle
+
+
+class CircleTypeTest(unittest.TestCase):
+
+    def testConstruction_invalid_type(self):
+        """Checks whether passing wrong types to the constructor
+         raises the appropriate errors
+         """
+        invalid_types = (None, [], "1", (1,), [1, 2, 3], Vector2(1, 1))
+
+        # Test x
+        for value in invalid_types:
+            with self.assertRaises(TypeError):
+                c = Circle(value, 0, 1)
+        # Test y
+        for value in invalid_types:
+            with self.assertRaises(TypeError):
+                c = Circle(0, value, 1)
+        # Test r
+        for value in invalid_types:
+            with self.assertRaises(TypeError):
+                c = Circle(0, 0, value)
+
+    def testConstruction_invalid_arguments_number(self):
+        """Checks whether passing the wrong number of arguments to the constructor
+           raises the appropriate errors
+        """
+        arguments = (
+            (1,),  # one non vec3 non circle arg
+            (1, 1),  # two args
+            (1, 1, 1, 1),  # four args
+        )
+
+        for arg_seq in arguments:
+            with self.assertRaises(TypeError):
+                c = Circle(*arg_seq)
+
+    def testConstructionXYR_float(self):
+
+        c = Circle(1.0, 2.0, 3.0)
+
+        self.assertEqual(1.0, c.x)
+        self.assertEqual(2.0, c.y)
+        self.assertEqual(3.0, c.r)
+
+    def testConstructionTUP_XYR_float(self):
+
+        c = Circle((1.0, 2.0, 3.0))
+
+        self.assertEqual(1.0, c.x)
+        self.assertEqual(2.0, c.y)
+        self.assertEqual(3.0, c.r)
+
+    def testConstructionXYR_int(self):
+
+        c = Circle(1, 2, 3)
+
+        self.assertEqual(1.0, c.x)
+        self.assertEqual(2.0, c.y)
+        self.assertEqual(3.0, c.r)
+
+    def testConstructionTUP_XYR_int(self):
+
+        c = Circle((1, 2, 3))
+
+        self.assertEqual(1.0, c.x)
+        self.assertEqual(2.0, c.y)
+        self.assertEqual(3.0, c.r)
+
+    def testCalculatedAttributes(self):
+        """Tests whether the circle correctly calculates the r_sqr attribute on creation
+        """
+        c = Circle(1.0, 2.0, 3.0)
+        self.assertEqual(9.0, c.r_sqr)
+
+    def test_x(self):
+        """Ensures changing the x attribute moves the circle and does not change
+        the circle's radius.
+        """
+        expected_x = 10.0
+        expected_y = 2.0
+        expected_radius = 5.0
+        c = Circle(1, expected_y, expected_radius)
+
+        c.x = expected_x
+
+        self.assertEqual(c.x, expected_x)
+        self.assertEqual(c.y, expected_y)
+        self.assertEqual(c.r, expected_radius)
+
+    def test_x__invalid_value(self):
+        """Ensures the x attribute handles invalid values correctly."""
+        c = Circle(0, 0, 1)
+
+        for value in (None, [], "1", (1,), [1, 2, 3]):
+            with self.assertRaises(TypeError):
+                c.x = value
+
+    def test_x__del(self):
+        """Ensures the x attribute can't be deleted."""
+        c = Circle(0, 0, 1)
+
+        with self.assertRaises(AttributeError):
+            del c.x
+
+    def test_y(self):
+        """Ensures changing the y attribute moves the circle and does not change
+        the circle's radius.
+        """
+        expected_x = 10.0
+        expected_y = 2.0
+        expected_radius = 5.0
+        c = Circle(expected_x, 1, expected_radius)
+
+        c.y = expected_y
+
+        self.assertEqual(c.x, expected_x)
+        self.assertEqual(c.y, expected_y)
+        self.assertEqual(c.r, expected_radius)
+
+    def test_y__invalid_value(self):
+        """Ensures the y attribute handles invalid values correctly."""
+        c = Circle(0, 0, 1)
+
+        for value in (None, [], "1", (1,), [1, 2, 3]):
+            with self.assertRaises(TypeError):
+                c.y = value
+
+    def test_y__del(self):
+        """Ensures the y attribute can't be deleted."""
+        c = Circle(0, 0, 1)
+
+        with self.assertRaises(AttributeError):
+            del c.y
+
+    def test_r(self):
+        """Ensures changing the r attribute changes the radius without moving the circle.
+        """
+        expected_x = 10.0
+        expected_y = 2.0
+        expected_radius = 5.0
+        c = Circle(expected_x, expected_y, 1.0)
+
+        c.r = expected_radius
+
+        self.assertEqual(c.x, expected_x)
+        self.assertEqual(c.y, expected_y)
+        self.assertEqual(c.r, expected_radius)
+
+    def test_r__invalid_value(self):
+        """Ensures the r attribute handles invalid values correctly."""
+        c = Circle(0, 0, 1)
+
+        for value in (None, [], "1", (1,), [1, 2, 3]):
+            with self.assertRaises(TypeError):
+                c.r = value
+
+    def test_r__del(self):
+        """Ensures the r attribute can't be deleted."""
+        c = Circle(0, 0, 1)
+
+        with self.assertRaises(AttributeError):
+            del c.r
+
+    def test_r_sqr(self):
+        """Ensures changing the r attribute correctly changes the r_sqr attribute.
+        """
+        expected_r_sqr = 1.0
+        expected_r_sqr2 = 100.0
+
+        c = Circle(0, 0, 23)
+        c2 = Circle(0, 0, 4)
+
+        c.r = 1
+        self.assertEqual(c.r_sqr, expected_r_sqr)
+
+        c2.r = 10
+        self.assertEqual(c2.r_sqr, expected_r_sqr2)
+
+    def test_r_sqr__invalid_set(self):
+        """Ensures the r_sqr attribute can't be set"""
+        c = Circle(0, 0, 1)
+
+        for value in (None, [], "1", (1,), [1, 2, 3]):
+            with self.assertRaises(AttributeError):
+                c.r_sqr = value
+
+    def test_r_sqr__del(self):
+        """Ensures the r attribute can't be deleted."""
+        c = Circle(0, 0, 1)
+
+        with self.assertRaises(AttributeError):
+            del c.r
+
+    def test_copy(self):
+        c = Circle(10, 10, 4)
+        # check 1 arg passed
+        with self.assertRaises(TypeError):
+            c.copy(10)
+
+        # check copied circle has the same attribute values
+        c_2 = c.copy()
+        self.assertEqual(c.x, c_2.x)
+        self.assertEqual(c.y, c_2.y)
+        self.assertEqual(c.r, c_2.r)
+        self.assertEqual(c.r_sqr, c_2.r_sqr)
+
+        # check c2 is not c
+        self.assertIsNot(c_2, c)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/unittests/circle_test.py
+++ b/unittests/circle_test.py
@@ -1,4 +1,5 @@
 import unittest
+from math import sqrt
 
 from pygame import Vector2
 
@@ -168,6 +169,15 @@ class CircleTypeTest(unittest.TestCase):
             del c.r
 
     def test_r_sqr(self):
+        """Ensures setting the r_sqr attribute matches the r_sqr passed
+        """
+        expected_r_sqr = 10.0
+        c = Circle(1.0, 1.0, 1.0)
+        c.r_sqr = expected_r_sqr
+
+        self.assertEqual(c.r_sqr, expected_r_sqr)
+
+    def test_r_to_r_sqr(self):
         """Ensures changing the r attribute correctly changes the r_sqr attribute.
         """
         expected_r_sqr = 1.0
@@ -182,12 +192,25 @@ class CircleTypeTest(unittest.TestCase):
         c2.r = 10
         self.assertEqual(c2.r_sqr, expected_r_sqr2)
 
+    def test_r_sqr_to_r(self):
+        """Ensures changing the r_sqr attribute correctly changes the r attribute.
+        """
+        expected_r = 2.0
+
+        c = Circle(0, 0, 23)
+
+        c.r_sqr = 4.0
+        self.assertEqual(c.r, expected_r)
+
+        c.r_sqr = 13.33421
+        self.assertEqual(c.r, sqrt(13.33421))
+
     def test_r_sqr__invalid_set(self):
         """Ensures the r_sqr attribute can't be set"""
         c = Circle(0, 0, 1)
 
         for value in (None, [], "1", (1,), [1, 2, 3]):
-            with self.assertRaises(AttributeError):
+            with self.assertRaises(TypeError):
                 c.r_sqr = value
 
     def test_r_sqr__del(self):
@@ -217,8 +240,8 @@ class CircleTypeTest(unittest.TestCase):
         c = Circle(10, 10, 4)
         c2 = Circle(10, 10, 0)
 
-        self.assertTrue(c, "Expected c to be True as radius is >= 0")
-        self.assertFalse(c2, "Expected c to be False as radius is < 0")
+        self.assertTrue(c, "Expected c to be True as radius is > 0")
+        self.assertFalse(c2, "Expected c to be False as radius is != 0")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR does many things:
- Adds a first batch of unit tests for the Circle type.
- Fixes a problem we had with getters not raising TypeError on wrong type.
- Adds the Circle type to the geometry.pyi file
- Added path for single item sequences in pgCircle_FromObject
- Circle no longer supports negative radius creation and assignment