### PR TITLE
Updated GH workflow names to reflect OS name

### DIFF
--- a/.github/workflows/ubuntu_test.yml
+++ b/.github/workflows/ubuntu_test.yml
@@ -1,4 +1,4 @@
-name: Ubuntu latest / build
+name: Ubuntu latest
 
 on: [push, pull_request]
 

--- a/.github/workflows/ubuntu_test.yml
+++ b/.github/workflows/ubuntu_test.yml
@@ -1,4 +1,4 @@
-name: Unit Test
+name: Ubuntu latest / build
 
 on: [push, pull_request]
 

--- a/.github/workflows/windows_test.yml
+++ b/.github/workflows/windows_test.yml
@@ -1,4 +1,4 @@
-name: Windows latest / build
+name: Windows latest
 
 on: [push, pull_request]
 

--- a/.github/workflows/windows_test.yml
+++ b/.github/workflows/windows_test.yml
@@ -1,4 +1,4 @@
-name: Unit Test
+name: Windows latest / build
 
 on: [push, pull_request]
 


### PR DESCRIPTION
Previously all workflow names were `Unit Test`, now they are called:
- `Ubuntu latest` for Ubuntu
- `Windows latest` for Windows