### PR TITLE
Make all shapes use floats

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,8 +3,21 @@ import subprocess
 import shlex
 import glob
 import sys
+import os
 
-extensions = [Extension("geometry", sources=["src_c/geometry.c"])]
+
+compiler_options = {"unix": ["-mavx2"], "msvc": ["/arch:AVX2"]}
+
+compiler_type = "msvc" if os.name == "nt" else "unix"
+
+
+extensions = [
+    Extension(
+        "geometry",
+        sources=["src_c/geometry.c"],
+        extra_compile_args=compiler_options[compiler_type],
+    )
+]
 
 
 def build() -> None:

--- a/src_c/circle.c
+++ b/src_c/circle.c
@@ -380,10 +380,9 @@ static PyObject *
 pg_circle_repr(pgCircleObject *self)
 {
     // dont comments on it (-_-)
-    return PyUnicode_FromFormat("pygame.Circle(%S, %S, %S)",
-                                PyFloat_FromFloat(self->circle.x),
-                                PyFloat_FromFloat(self->circle.y),
-                                PyFloat_FromFloat(self->circle.r));
+    return PyUnicode_FromFormat(
+        "pygame.Circle(%S, %S, %S)", PyFloat_FromFloat(self->circle.x),
+        PyFloat_FromFloat(self->circle.y), PyFloat_FromFloat(self->circle.r));
 }
 
 static PyObject *

--- a/src_c/circle.c
+++ b/src_c/circle.c
@@ -14,7 +14,7 @@ static int
 pg_circle_init(pgCircleObject *, PyObject *, PyObject *);
 
 static PyObject *
-_pg_circle_subtype_new3(PyTypeObject *type, double x, double y, double r)
+_pg_circle_subtype_new3(PyTypeObject *type, float x, float y, float r)
 {
     pgCircleObject *circle_obj =
         (pgCircleObject *)pgCircle_Type.tp_new(type, NULL, NULL);
@@ -55,8 +55,8 @@ pg_circle_dealloc(pgCircleObject *self)
 static int
 _pg_circle_set_radius(PyObject *value, pgCircleBase *circle)
 {
-    double tmp = 0;
-    if (!pg_DoubleFromObj(value, &tmp) || tmp < 0)
+    float tmp = 0;
+    if (!pg_FloatFromObj(value, &tmp) || tmp < 0)
         return 0;
     circle->r = tmp;
     circle->r_sqr = tmp * tmp;
@@ -78,8 +78,8 @@ pgCircle_FromObject(PyObject *obj, pgCircleBase *out)
         length = PySequence_Fast_GET_SIZE(obj);
 
         if (length == 3) {
-            if (!pg_DoubleFromObj(f_arr[0], &(out->x)) ||
-                !pg_DoubleFromObj(f_arr[1], &(out->y)) ||
+            if (!pg_FloatFromObj(f_arr[0], &(out->x)) ||
+                !pg_FloatFromObj(f_arr[1], &(out->y)) ||
                 !_pg_circle_set_radius(f_arr[2], out)) {
                 return 0;
             }
@@ -105,14 +105,14 @@ pgCircle_FromObject(PyObject *obj, pgCircleBase *out)
             /*These are to be substituted with better pg_DoubleFromSeqIndex()
              * implementations*/
             tmp = PySequence_ITEM(obj, 0);
-            if (!pg_DoubleFromObj(tmp, &(out->x))) {
+            if (!pg_FloatFromObj(tmp, &(out->x))) {
                 Py_DECREF(tmp);
                 return 0;
             }
             Py_DECREF(tmp);
 
             tmp = PySequence_ITEM(obj, 1);
-            if (!pg_DoubleFromObj(tmp, &(out->y))) {
+            if (!pg_FloatFromObj(tmp, &(out->y))) {
                 Py_DECREF(tmp);
                 return 0;
             }
@@ -180,8 +180,8 @@ pgCircle_FromObjectFastcall(PyObject *const *args, Py_ssize_t nargs,
         return pgCircle_FromObject(args[0], out);
     }
     else if (nargs == 3) {
-        if (!pg_DoubleFromObj(args[0], &(out->x)) ||
-            !pg_DoubleFromObj(args[1], &(out->y)) ||
+        if (!pg_FloatFromObj(args[0], &(out->x)) ||
+            !pg_FloatFromObj(args[1], &(out->y)) ||
             !_pg_circle_set_radius(args[2], out)) {
             return 0;
         }
@@ -198,7 +198,7 @@ pgCircle_New(pgCircleBase *c)
 }
 
 static PyObject *
-pgCircle_New3(double x, double y, double r)
+pgCircle_New3(float x, float y, float r)
 {
     return _pg_circle_subtype_new3(&pgCircle_Type, x, y, r);
 }
@@ -237,16 +237,15 @@ static PyObject *
 pg_circle_collidepoint(pgCircleObject *self, PyObject *const *args,
                        Py_ssize_t nargs)
 {
-    double px = 0, py = 0;
+    float px = 0, py = 0;
 
     if (nargs == 1) {
-        if (!pg_TwoDoublesFromObj(args[0], &px, &py)) {
+        if (!pg_TwoFloatsFromObj(args[0], &px, &py)) {
             goto error;
         }
     }
     else if (nargs == 2) {
-        if (!pg_DoubleFromObj(args[0], &px) ||
-            !pg_DoubleFromObj(args[1], &py)) {
+        if (!pg_FloatFromObj(args[0], &px) || !pg_FloatFromObj(args[1], &py)) {
             goto error;
         }
     }
@@ -314,8 +313,8 @@ pg_circle_collideswith(pgCircleObject *self, PyObject *arg)
         result = pgCollision_RectCircle(&pgRect_AsRect(arg), &self->circle);
     }
     else if (PySequence_Check(arg)) {
-        double x, y;
-        if (!pg_TwoDoublesFromObj(arg, &x, &y)) {
+        float x, y;
+        if (!pg_TwoFloatsFromObj(arg, &x, &y)) {
             return RAISE(PyExc_TypeError,
                          "Invalid arguments, must be a sequence of 2 numbers");
         }
@@ -392,7 +391,7 @@ static PyObject *
 pg_circle_richcompare(PyObject *o1, PyObject *o2, int opid)
 {
     pgCircleBase o1_circ, o2_circ;
-    double r1, r2;
+    float r1, r2;
 
     if (!pgCircle_FromObject(o1, &o1_circ) ||
         !pgCircle_FromObject(o1, &o2_circ)) {
@@ -431,9 +430,9 @@ pg_circle_richcompare(PyObject *o1, PyObject *o2, int opid)
     static int pg_circle_set##name(pgCircleObject *self, PyObject *value,     \
                                    void *closure)                             \
     {                                                                         \
-        double val;                                                           \
+        float val;                                                            \
         DEL_ATTR_NOT_SUPPORTED_CHECK_NO_NAME(value);                          \
-        if (pg_DoubleFromObj(value, &val)) {                                  \
+        if (pg_FloatFromObj(value, &val)) {                                   \
             self->circle.name = val;                                          \
             return 0;                                                         \
         }                                                                     \
@@ -456,10 +455,10 @@ pg_circle_getr(pgCircleObject *self, void *closure)
 static int
 pg_circle_setr(pgCircleObject *self, PyObject *value, void *closure)
 {
-    double val;
+    float val;
     DEL_ATTR_NOT_SUPPORTED_CHECK_NO_NAME(value);
 
-    if (!pg_DoubleFromObj(value, &val) || val < 0) {
+    if (!pg_FloatFromObj(value, &val) || val < 0) {
         PyErr_SetString(PyExc_TypeError, "Expected a positive number");
         return -1;
     }
@@ -478,16 +477,16 @@ pg_circle_getr_sqr(pgCircleObject *self, void *closure)
 static int
 pg_circle_setr_sqr(pgCircleObject *self, PyObject *value, void *closure)
 {
-    double val;
+    float val;
     DEL_ATTR_NOT_SUPPORTED_CHECK_NO_NAME(value);
 
-    if (!pg_DoubleFromObj(value, &val) || val < 0) {
+    if (!pg_FloatFromObj(value, &val) || val < 0) {
         PyErr_SetString(PyExc_TypeError, "Expected a positive number");
         return -1;
     }
 
     self->circle.r_sqr = val;
-    self->circle.r = sqrt(val);
+    self->circle.r = sqrtf(val);
     return 0;
 }
 
@@ -501,7 +500,7 @@ static int
 pg_circle_setcenter(pgCircleObject *self, PyObject *value, void *closure)
 {
     DEL_ATTR_NOT_SUPPORTED_CHECK_NO_NAME(value);
-    if (!pg_TwoDoublesFromObj(value, &(self->circle.x), &(self->circle.y))) {
+    if (!pg_TwoFloatsFromObj(value, &(self->circle.x), &(self->circle.y))) {
         PyErr_SetString(PyExc_TypeError, "Expected a sequence of 2 numbers");
         return -1;
     }
@@ -517,14 +516,14 @@ pg_circle_getarea(pgCircleObject *self, void *closure)
 static int
 pg_circle_setarea(pgCircleObject *self, PyObject *value, void *closure)
 {
-    double val;
+    float val;
     DEL_ATTR_NOT_SUPPORTED_CHECK_NO_NAME(value);
-    if (!pg_DoubleFromObj(value, &val) || val <= 0) {
+    if (!pg_FloatFromObj(value, &val) || val <= 0) {
         PyErr_SetString(PyExc_TypeError, "Expected a positive number");
         return -1;
     }
     self->circle.r_sqr = val / PI;
-    self->circle.r = sqrt(self->circle.r_sqr);
+    self->circle.r = sqrtf(self->circle.r_sqr);
     return 0;
 }
 
@@ -538,9 +537,9 @@ static int
 pg_circle_setcircumference(pgCircleObject *self, PyObject *value,
                            void *closure)
 {
-    double val;
+    float val;
     DEL_ATTR_NOT_SUPPORTED_CHECK_NO_NAME(value);
-    if (!pg_DoubleFromObj(value, &val) || val <= 0) {
+    if (!pg_FloatFromObj(value, &val) || val <= 0) {
         PyErr_SetString(PyExc_TypeError, "Expected a positive number");
         return -1;
     }

--- a/src_c/circle.c
+++ b/src_c/circle.c
@@ -11,8 +11,13 @@
 #define TAU (float)6.28318530717958647692528
 
 #ifndef PyFloat_FromFloat
-#define PyFloat_FromFloat(x) \
-    (PyFloat_FromDouble((double)(round((x)*10000000) / 10000000)))
+#define PyFloat_FromFloat(x) (PyFloat_FromDouble((double)(x)))
+#endif
+#ifndef PyFloat_AsFloat
+#define PyFloat_AsFloat(x) ((float)PyFloat_AsDouble(x))
+#endif
+#ifndef PyFloat_ASFLOAT
+#define PyFloat_ASFLOAT(x) ((float)PyFloat_AS_DOUBLE(x))
 #endif
 
 static int

--- a/src_c/circle.c
+++ b/src_c/circle.c
@@ -376,9 +376,9 @@ pg_circle_repr(pgCircleObject *self)
 {
     // dont comments on it (-_-)
     return PyUnicode_FromFormat("pygame.Circle(%S, %S, %S)",
-                                PyFloat_FromDouble(self->circle.x),
-                                PyFloat_FromDouble(self->circle.y),
-                                PyFloat_FromDouble(self->circle.r));
+                                PyFloat_FromDouble((double)(self->circle.x)),
+                                PyFloat_FromDouble((double)(self->circle.y)),
+                                PyFloat_FromDouble((double)(self->circle.r)));
 }
 
 static PyObject *
@@ -425,7 +425,7 @@ pg_circle_richcompare(PyObject *o1, PyObject *o2, int opid)
 #define GETSET_FOR_SIMPLE(name)                                               \
     static PyObject *pg_circle_get##name(pgCircleObject *self, void *closure) \
     {                                                                         \
-        return PyFloat_FromDouble(self->circle.name);                         \
+        return PyFloat_FromDouble((double)(self->circle.name));                         \
     }                                                                         \
     static int pg_circle_set##name(pgCircleObject *self, PyObject *value,     \
                                    void *closure)                             \
@@ -449,7 +449,7 @@ GETSET_FOR_SIMPLE(y)
 static PyObject *
 pg_circle_getr(pgCircleObject *self, void *closure)
 {
-    return PyFloat_FromDouble(self->circle.r);
+    return PyFloat_FromDouble((double)(self->circle.r));
 }
 
 static int
@@ -471,7 +471,7 @@ pg_circle_setr(pgCircleObject *self, PyObject *value, void *closure)
 static PyObject *
 pg_circle_getr_sqr(pgCircleObject *self, void *closure)
 {
-    return PyFloat_FromDouble(self->circle.r_sqr);
+    return PyFloat_FromDouble((double)(self->circle.r_sqr));
 }
 
 static int
@@ -510,7 +510,7 @@ pg_circle_setcenter(pgCircleObject *self, PyObject *value, void *closure)
 static PyObject *
 pg_circle_getarea(pgCircleObject *self, void *closure)
 {
-    return PyFloat_FromDouble(PI * self->circle.r_sqr);
+    return PyFloat_FromDouble((double)(PI * self->circle.r_sqr));
 }
 
 static int
@@ -530,7 +530,7 @@ pg_circle_setarea(pgCircleObject *self, PyObject *value, void *closure)
 static PyObject *
 pg_circle_getcircumference(pgCircleObject *self, void *closure)
 {
-    return PyFloat_FromDouble(TAU * self->circle.r);
+    return PyFloat_FromDouble((double)(TAU * self->circle.r));
 }
 
 static int

--- a/src_c/circle.c
+++ b/src_c/circle.c
@@ -425,7 +425,7 @@ pg_circle_richcompare(PyObject *o1, PyObject *o2, int opid)
 #define GETSET_FOR_SIMPLE(name)                                               \
     static PyObject *pg_circle_get##name(pgCircleObject *self, void *closure) \
     {                                                                         \
-        return PyFloat_FromDouble((double)(self->circle.name));                         \
+        return PyFloat_FromDouble((double)(self->circle.name));               \
     }                                                                         \
     static int pg_circle_set##name(pgCircleObject *self, PyObject *value,     \
                                    void *closure)                             \

--- a/src_c/circle.c
+++ b/src_c/circle.c
@@ -10,6 +10,11 @@
 #define PI 3.14159265358979323846264
 #define TAU 6.28318530717958647692528
 
+#ifndef PyFloat_FromFloat
+#define PyFloat_FromFloat(x) \
+    (PyFloat_FromDouble((double)(round((x)*10000000) / 10000000)))
+#endif
+
 static int
 pg_circle_init(pgCircleObject *, PyObject *, PyObject *);
 
@@ -376,9 +381,9 @@ pg_circle_repr(pgCircleObject *self)
 {
     // dont comments on it (-_-)
     return PyUnicode_FromFormat("pygame.Circle(%S, %S, %S)",
-                                PyFloat_FromDouble((double)(self->circle.x)),
-                                PyFloat_FromDouble((double)(self->circle.y)),
-                                PyFloat_FromDouble((double)(self->circle.r)));
+                                PyFloat_FromFloat(self->circle.x),
+                                PyFloat_FromFloat(self->circle.y),
+                                PyFloat_FromFloat(self->circle.r));
 }
 
 static PyObject *
@@ -425,7 +430,7 @@ pg_circle_richcompare(PyObject *o1, PyObject *o2, int opid)
 #define GETSET_FOR_SIMPLE(name)                                               \
     static PyObject *pg_circle_get##name(pgCircleObject *self, void *closure) \
     {                                                                         \
-        return PyFloat_FromDouble((double)(self->circle.name));               \
+        return PyFloat_FromFloat(self->circle.name);                          \
     }                                                                         \
     static int pg_circle_set##name(pgCircleObject *self, PyObject *value,     \
                                    void *closure)                             \
@@ -449,7 +454,7 @@ GETSET_FOR_SIMPLE(y)
 static PyObject *
 pg_circle_getr(pgCircleObject *self, void *closure)
 {
-    return PyFloat_FromDouble((double)(self->circle.r));
+    return PyFloat_FromFloat(self->circle.r);
 }
 
 static int
@@ -471,7 +476,7 @@ pg_circle_setr(pgCircleObject *self, PyObject *value, void *closure)
 static PyObject *
 pg_circle_getr_sqr(pgCircleObject *self, void *closure)
 {
-    return PyFloat_FromDouble((double)(self->circle.r_sqr));
+    return PyFloat_FromFloat(self->circle.r_sqr);
 }
 
 static int
@@ -510,7 +515,7 @@ pg_circle_setcenter(pgCircleObject *self, PyObject *value, void *closure)
 static PyObject *
 pg_circle_getarea(pgCircleObject *self, void *closure)
 {
-    return PyFloat_FromDouble((double)(PI * self->circle.r_sqr));
+    return PyFloat_FromFloat(PI * self->circle.r_sqr);
 }
 
 static int
@@ -530,7 +535,7 @@ pg_circle_setarea(pgCircleObject *self, PyObject *value, void *closure)
 static PyObject *
 pg_circle_getcircumference(pgCircleObject *self, void *closure)
 {
-    return PyFloat_FromDouble((double)(TAU * self->circle.r));
+    return PyFloat_FromFloat(TAU * self->circle.r);
 }
 
 static int

--- a/src_c/collisions.c
+++ b/src_c/collisions.c
@@ -122,9 +122,9 @@ pgIntersection_LineCircle(pgLineBase *line, pgCircleBase *circle, float *X,
     if (descriminant < 0) {
         return 0;
     }
-    float t = (-B - sqrt(descriminant)) / (2 * A);
+    float t = (-B - sqrtf(descriminant)) / (2 * A);
     if (t < 0 || t > 1) {
-        t = (-B + sqrt(descriminant)) / (2 * A);
+        t = (-B + sqrtf(descriminant)) / (2 * A);
         if (t < 0 || t > 1) {
             return 0;
         }
@@ -156,7 +156,7 @@ pgCollision_LineCircle(pgLineBase *line, pgCircleBase *circle)
 
     float dx = x1 - x2;
     float dy = y1 - y2;
-    float len = sqrt((dx * dx) + (dy * dy));
+    float len = sqrtf((dx * dx) + (dy * dy));
 
     float dot =
         (((cx - x1) * (x2 - x1)) + ((cy - y1) * (y2 - y1))) / (len * len);
@@ -170,7 +170,7 @@ pgCollision_LineCircle(pgLineBase *line, pgCircleBase *circle)
 
     dx = closest_x - cx;
     dy = closest_y - cy;
-    float distance = sqrt((dx * dx) + (dy * dy));
+    float distance = sqrtf((dx * dx) + (dy * dy));
 
     return distance <= r;
 }

--- a/src_c/collisions.c
+++ b/src_c/collisions.c
@@ -8,75 +8,63 @@
 #define DOT2D(X0, Y0, X1, Y1) ((X0) * (X1) + (Y0) * (Y1))
 #endif /* ~DOT2D */
 
-#ifndef CODE_BOTTOM
-#define CODE_BOTTOM 1
-#endif /* CODE_BOTTOM */
-#ifndef CODE_TOP
-#define CODE_TOP 2
-#endif /* CODE_TOP */
-#ifndef CODE_LEFT
-#define CODE_LEFT 4
-#endif /* CODE_LEFT */
-#ifndef CODE_RIGHT
-#define CODE_RIGHT 8
-#endif /* CODE_RIGHT */
 
 static int
 pgCollision_LineLine(pgLineBase *A, pgLineBase *B)
 {
-    double x1_m_x2 = A->x1 - A->x2;
-    double y3_m_y4 = B->y1 - B->y2;
-    double y1_m_y2 = A->y1 - A->y2;
-    double x3_m_x4 = B->x1 - B->x2;
+    float x1_m_x2 = A->x1 - A->x2;
+    float y3_m_y4 = B->y1 - B->y2;
+    float y1_m_y2 = A->y1 - A->y2;
+    float x3_m_x4 = B->x1 - B->x2;
 
-    double den = x1_m_x2 * y3_m_y4 - y1_m_y2 * x3_m_x4;
+    float den = x1_m_x2 * y3_m_y4 - y1_m_y2 * x3_m_x4;
 
     if (!den)
         return 0;
 
-    double x1_m_x3 = A->x1 - B->x1;
-    double y1_m_y3 = A->y1 - B->y1;
+    float x1_m_x3 = A->x1 - B->x1;
+    float y1_m_y3 = A->y1 - B->y1;
 
-    double t1 = x1_m_x3 * y3_m_y4 - y1_m_y3 * x3_m_x4;
-    double t = t1 / den;
+    float t1 = x1_m_x3 * y3_m_y4 - y1_m_y3 * x3_m_x4;
+    float t = t1 / den;
 
-    double u1 = x1_m_x2 * y1_m_y3 - y1_m_y2 * x1_m_x3;
-    double u = -(u1 / den);
+    float u1 = x1_m_x2 * y1_m_y3 - y1_m_y2 * x1_m_x3;
+    float u = -(u1 / den);
 
     return t >= 0 && t <= 1 && u >= 0 && u <= 1;
 }
 
 static int
-pgIntersection_LineLine(pgLineBase *A, pgLineBase *B, double *X, double *Y,
-                        double *T)
+pgIntersection_LineLine(pgLineBase *A, pgLineBase *B, float *X, float *Y,
+                        float *T)
 {
-    double x1 = A->x1;
-    double y1 = A->y1;
-    double x2 = A->x2;
-    double y2 = A->y2;
-    double x3 = B->x1;
-    double y3 = B->y1;
-    double x4 = B->x2;
-    double y4 = B->y2;
+    float x1 = A->x1;
+    float y1 = A->y1;
+    float x2 = A->x2;
+    float y2 = A->y2;
+    float x3 = B->x1;
+    float y3 = B->y1;
+    float x4 = B->x2;
+    float y4 = B->y2;
 
-    double x1_m_x2 = x1 - x2;
-    double y3_m_y4 = y3 - y4;
-    double y1_m_y2 = y1 - y2;
-    double x3_m_x4 = x3 - x4;
+    float x1_m_x2 = x1 - x2;
+    float y3_m_y4 = y3 - y4;
+    float y1_m_y2 = y1 - y2;
+    float x3_m_x4 = x3 - x4;
 
-    double den = x1_m_x2 * y3_m_y4 - y1_m_y2 * x3_m_x4;
+    float den = x1_m_x2 * y3_m_y4 - y1_m_y2 * x3_m_x4;
 
     if (!den)
         return 0;
 
-    double x1_m_x3 = x1 - x3;
-    double y1_m_y3 = y1 - y3;
+    float x1_m_x3 = x1 - x3;
+    float y1_m_y3 = y1 - y3;
 
-    double t1 = x1_m_x3 * y3_m_y4 - y1_m_y3 * x3_m_x4;
-    double t = t1 / den;
+    float t1 = x1_m_x3 * y3_m_y4 - y1_m_y3 * x3_m_x4;
+    float t = t1 / den;
 
-    double u1 = x1_m_x2 * y1_m_y3 - y1_m_y2 * x1_m_x3;
-    double u = -(u1 / den);
+    float u1 = x1_m_x2 * y1_m_y3 - y1_m_y2 * x1_m_x3;
+    float u = -(u1 / den);
 
     if (t >= 0 && t <= 1 && u >= 0 && u <= 1) {
         if (X)
@@ -91,12 +79,12 @@ pgIntersection_LineLine(pgLineBase *A, pgLineBase *B, double *X, double *Y,
 }
 
 static int
-pgCollision_LinePoint(pgLineBase *line, double Cx, double Cy)
+pgCollision_LinePoint(pgLineBase *line, float Cx, float Cy)
 {
-    double Ax = line->x1;
-    double Ay = line->y1;
-    double Bx = line->x2;
-    double By = line->y2;
+    float Ax = line->x1;
+    float Ay = line->y1;
+    float Bx = line->x2;
+    float By = line->y2;
 
     /* https://en.wikipedia.org/wiki/Line%E2%80%93line_intersection */
     return (Bx - Ax) * (Cy - Ay) == (Cx - Ax) * (By - Ay) &&
@@ -105,36 +93,36 @@ pgCollision_LinePoint(pgLineBase *line, double Cx, double Cy)
 }
 
 static int
-pgCollision_CirclePoint(pgCircleBase *circle, double Cx, double Cy)
+pgCollision_CirclePoint(pgCircleBase *circle, float Cx, float Cy)
 {
-    double dx = circle->x - Cx;
-    double dy = circle->y - Cy;
+    float dx = circle->x - Cx;
+    float dy = circle->y - Cy;
     return dx * dx + dy * dy <= circle->r_sqr;
 }
 
 static int
-pgIntersection_LineCircle(pgLineBase *line, pgCircleBase *circle, double *X,
-                          double *Y, double *T)
+pgIntersection_LineCircle(pgLineBase *line, pgCircleBase *circle, float *X,
+                          float *Y, float *T)
 {
-    double x1 = line->x1;
-    double y1 = line->y1;
-    double x2 = line->x2;
-    double y2 = line->y2;
-    double xc = circle->x;
-    double yc = circle->y;
-    double r = circle->r;
-    double rsq = circle->r_sqr;
+    float x1 = line->x1;
+    float y1 = line->y1;
+    float x2 = line->x2;
+    float y2 = line->y2;
+    float xc = circle->x;
+    float yc = circle->y;
+    float r = circle->r;
+    float rsq = circle->r_sqr;
 
-    double dx = x2 - x1;
-    double dy = y2 - y1;
-    double A = dx * dx + dy * dy;
-    double B = 2 * (dx * (x1 - xc) + dy * (y1 - yc));
-    double C = (x1 - xc) * (x1 - xc) + (y1 - yc) * (y1 - yc) - rsq;
-    double descriminant = B * B - 4 * A * C;
+    float dx = x2 - x1;
+    float dy = y2 - y1;
+    float A = dx * dx + dy * dy;
+    float B = 2 * (dx * (x1 - xc) + dy * (y1 - yc));
+    float C = (x1 - xc) * (x1 - xc) + (y1 - yc) * (y1 - yc) - rsq;
+    float descriminant = B * B - 4 * A * C;
     if (descriminant < 0) {
         return 0;
     }
-    double t = (-B - sqrt(descriminant)) / (2 * A);
+    float t = (-B - sqrt(descriminant)) / (2 * A);
     if (t < 0 || t > 1) {
         t = (-B + sqrt(descriminant)) / (2 * A);
         if (t < 0 || t > 1) {
@@ -154,27 +142,27 @@ pgIntersection_LineCircle(pgLineBase *line, pgCircleBase *circle, double *X,
 static int
 pgCollision_LineCircle(pgLineBase *line, pgCircleBase *circle)
 {
-    double x1 = line->x1;
-    double y1 = line->y1;
-    double x2 = line->x2;
-    double y2 = line->y2;
-    double cx = circle->x;
-    double cy = circle->y;
-    double r = circle->r;
+    float x1 = line->x1;
+    float y1 = line->y1;
+    float x2 = line->x2;
+    float y2 = line->y2;
+    float cx = circle->x;
+    float cy = circle->y;
+    float r = circle->r;
 
     if (pgCollision_CirclePoint(circle, x1, y1) ||
         pgCollision_CirclePoint(circle, x2, y2))
         return 1;
 
-    double dx = x1 - x2;
-    double dy = y1 - y2;
-    double len = sqrt((dx * dx) + (dy * dy));
+    float dx = x1 - x2;
+    float dy = y1 - y2;
+    float len = sqrt((dx * dx) + (dy * dy));
 
-    double dot =
+    float dot =
         (((cx - x1) * (x2 - x1)) + ((cy - y1) * (y2 - y1))) / (len * len);
 
-    double closest_x = x1 + (dot * (x2 - x1));
-    double closest_y = y1 + (dot * (y2 - y1));
+    float closest_x = x1 + (dot * (x2 - x1));
+    float closest_y = y1 + (dot * (y2 - y1));
 
     pgLineBase line2 = {x1, y1, x2, y2};
     if (!pgCollision_LinePoint(&line2, closest_x, closest_y))
@@ -182,7 +170,7 @@ pgCollision_LineCircle(pgLineBase *line, pgCircleBase *circle)
 
     dx = closest_x - cx;
     dy = closest_y - cy;
-    double distance = sqrt((dx * dx) + (dy * dy));
+    float distance = sqrt((dx * dx) + (dy * dy));
 
     return distance <= r;
 }
@@ -190,8 +178,8 @@ pgCollision_LineCircle(pgLineBase *line, pgCircleBase *circle)
 static int
 pgCollision_CircleCircle(pgCircleBase *A, pgCircleBase *B)
 {
-    double dx, dy;
-    double sum_radi;
+    float dx, dy;
+    float sum_radi;
 
     dx = A->x - B->x;
     dy = A->y - B->y;
@@ -201,13 +189,13 @@ pgCollision_CircleCircle(pgCircleBase *A, pgCircleBase *B)
 }
 
 static int
-pgIntersection_LineRect(pgLineBase *line, SDL_Rect *rect, double *X, double *Y,
-                        double *T)
+pgIntersection_LineRect(pgLineBase *line, SDL_Rect *rect, float *X, float *Y,
+                        float *T)
 {
-    double x = (double)rect->x;
-    double y = (double)rect->y;
-    double w = (double)rect->w;
-    double h = (double)rect->h;
+    float x = (float)rect->x;
+    float y = (float)rect->y;
+    float w = (float)rect->w;
+    float h = (float)rect->h;
 
     pgLineBase a = {x, y, x + w, y};
     pgLineBase b = {x, y, x, y + h};
@@ -216,8 +204,8 @@ pgIntersection_LineRect(pgLineBase *line, SDL_Rect *rect, double *X, double *Y,
 
     int ret = 0;
 
-    double temp_t = DBL_MAX;
-    double final_t = DBL_MAX;
+    float temp_t = FLT_MAX;
+    float final_t = FLT_MAX;
 
     ret |= pgIntersection_LineLine(line, &a, NULL, NULL, &temp_t);
     final_t = MIN(temp_t, final_t);
@@ -249,14 +237,14 @@ pgCollision_RectLine(SDL_Rect *rect, pgLineBase *line)
 static int
 pgCollision_RectCircle(SDL_Rect *rect, pgCircleBase *circle)
 {
-    double cx = circle->x, cy = circle->y;
-    double rx = (double)rect->x, ry = (double)rect->y;
-    double rw = (double)rect->w, rh = (double)rect->h;
-    double r_bottom = ry + rh;
-    double r_right = rx + rw;
+    float cx = circle->x, cy = circle->y;
+    float rx = (float)rect->x, ry = (float)rect->y;
+    float rw = (float)rect->w, rh = (float)rect->h;
+    float r_bottom = ry + rh;
+    float r_right = rx + rw;
 
-    double test_x = cx;
-    double test_y = cy;
+    float test_x = cx;
+    float test_y = cy;
 
     if (cx < rx) {
         test_x = rx;
@@ -272,8 +260,8 @@ pgCollision_RectCircle(SDL_Rect *rect, pgCircleBase *circle)
         test_y = r_bottom;
     }
 
-    double dx = cx - test_x;
-    double dy = cy - test_y;
+    float dx = cx - test_x;
+    float dy = cy - test_y;
 
     return dx * dx + dy * dy <= circle->r_sqr;
     return 0;

--- a/src_c/include/collisions.h
+++ b/src_c/include/collisions.h
@@ -13,22 +13,22 @@
 static int
 pgCollision_LineLine(pgLineBase *, pgLineBase *);
 static int
-pgIntersection_LineLine(pgLineBase *, pgLineBase *, double *, double *,
-                        double *);
+pgIntersection_LineLine(pgLineBase *, pgLineBase *, float *, float *,
+                        float *);
 static int
-pgCollision_LinePoint(pgLineBase *, double, double);
+pgCollision_LinePoint(pgLineBase *, float, float);
 static int
-pgCollision_CirclePoint(pgCircleBase *circle, double, double);
+pgCollision_CirclePoint(pgCircleBase *circle, float, float);
 static int
 pgCollision_LineCircle(pgLineBase *, pgCircleBase *);
 static int
-pgIntersection_LineCircle(pgLineBase *, pgCircleBase *, double *, double *,
-                          double *);
+pgIntersection_LineCircle(pgLineBase *, pgCircleBase *, float *, float *,
+                          float *);
 static int
 pgCollision_CircleCircle(pgCircleBase *, pgCircleBase *);
 static int
-pgIntersection_LineRect(pgLineBase *, SDL_Rect *, double *, double *,
-                        double *);
+pgIntersection_LineRect(pgLineBase *, SDL_Rect *, float *, float *,
+                        float *);
 static int
 pgCollision_RectLine(SDL_Rect *, pgLineBase *);
 static int

--- a/src_c/include/geometry.h
+++ b/src_c/include/geometry.h
@@ -4,7 +4,7 @@
 #include "pygame.h"
 
 typedef struct {
-    double x, y, r, r_sqr;
+    float x, y, r, r_sqr;
 } pgCircleBase;
 
 typedef struct {

--- a/src_c/include/geometry.h
+++ b/src_c/include/geometry.h
@@ -20,8 +20,8 @@ typedef struct {
 #define pgCircle_GETRSQR(self) (pgCircle_CAST(self)->circle.r_sqr)
 
 typedef struct {
-    double x1, y1;
-    double x2, y2;
+    float x1, y1;
+    float x2, y2;
 } pgLineBase;
 
 typedef struct {

--- a/src_c/line.c
+++ b/src_c/line.c
@@ -7,13 +7,18 @@
 #include <stddef.h>
 #include <math.h>
 
-static double
+#ifndef PyFloat_FromFloat
+#define PyFloat_FromFloat(x) \
+    (PyFloat_FromDouble((double)(round((x)*10000000) / 10000000)))
+#endif
+
+static float
 pgLine_Length(pgLineBase line)
 {
     return sqrt((line.x2 - line.x1) * (line.x2 - line.x1) +
                 (line.y2 - line.y1) * (line.y2 - line.y1));
 }
-static double
+static float
 pgLine_LengthSquared(pgLineBase line)
 {
     return (line.x2 - line.x1) * (line.x2 - line.x1) +
@@ -21,8 +26,8 @@ pgLine_LengthSquared(pgLineBase line)
 }
 
 static PyObject *
-_pg_line_subtype_new4(PyTypeObject *type, double x1, double y1, double x2,
-                      double y2)
+_pg_line_subtype_new4(PyTypeObject *type, float x1, float y1, float x2,
+                      float y2)
 {
     pgLineObject *line = (pgLineObject *)pgLine_Type.tp_new(type, NULL, NULL);
 
@@ -82,17 +87,17 @@ pgLine_FromObject(PyObject *obj, pgLineBase *out)
         PyObject **farray = PySequence_Fast_ITEMS(obj);
 
         if (length == 4) {
-            if (!pg_DoubleFromObj(farray[0], &(out->x1)) ||
-                !pg_DoubleFromObj(farray[1], &(out->y1)) ||
-                !pg_DoubleFromObj(farray[2], &(out->x2)) ||
-                !pg_DoubleFromObj(farray[3], &(out->y2))) {
+            if (!pg_FloatFromObj(farray[0], &(out->x1)) ||
+                !pg_FloatFromObj(farray[1], &(out->y1)) ||
+                !pg_FloatFromObj(farray[2], &(out->x2)) ||
+                !pg_FloatFromObj(farray[3], &(out->y2))) {
                 return 0;
             }
             return 1;
         }
         else if (length == 2) {
-            if (!pg_TwoDoublesFromObj(farray[0], &(out->x1), &(out->y1)) ||
-                !pg_TwoDoublesFromObj(farray[1], &(out->x2), &(out->y2))) {
+            if (!pg_TwoFloatsFromObj(farray[0], &(out->x1), &(out->y1)) ||
+                !pg_TwoFloatsFromObj(farray[1], &(out->x2), &(out->y2))) {
                 PyErr_Clear();
                 return 0;
             }
@@ -111,25 +116,25 @@ pgLine_FromObject(PyObject *obj, pgLineBase *out)
         if (length == 4) {
             PyObject *tmp;
             tmp = PySequence_GetItem(obj, 0);
-            if (!pg_DoubleFromObj(tmp, &(out->x1))) {
+            if (!pg_FloatFromObj(tmp, &(out->x1))) {
                 Py_DECREF(tmp);
                 return 0;
             }
             Py_DECREF(tmp);
             tmp = PySequence_GetItem(obj, 1);
-            if (!pg_DoubleFromObj(tmp, &(out->y1))) {
+            if (!pg_FloatFromObj(tmp, &(out->y1))) {
                 Py_DECREF(tmp);
                 return 0;
             }
             Py_DECREF(tmp);
             tmp = PySequence_GetItem(obj, 2);
-            if (!pg_DoubleFromObj(tmp, &(out->x2))) {
+            if (!pg_FloatFromObj(tmp, &(out->x2))) {
                 Py_DECREF(tmp);
                 return 0;
             }
             Py_DECREF(tmp);
             tmp = PySequence_GetItem(obj, 3);
-            if (!pg_DoubleFromObj(tmp, &(out->y2))) {
+            if (!pg_FloatFromObj(tmp, &(out->y2))) {
                 Py_DECREF(tmp);
                 return 0;
             }
@@ -139,13 +144,13 @@ pgLine_FromObject(PyObject *obj, pgLineBase *out)
         else if (length == 2) {
             PyObject *tmp;
             tmp = PySequence_GetItem(obj, 0);
-            if (!pg_TwoDoublesFromObj(tmp, &(out->x1), &(out->y1))) {
+            if (!pg_TwoFloatsFromObj(tmp, &(out->x1), &(out->y1))) {
                 Py_DECREF(tmp);
                 return 0;
             }
             Py_DECREF(tmp);
             tmp = PySequence_GetItem(obj, 1);
-            if (!pg_TwoDoublesFromObj(tmp, &(out->x2), &(out->y2))) {
+            if (!pg_TwoFloatsFromObj(tmp, &(out->x2), &(out->y2))) {
                 Py_DECREF(tmp);
                 return 0;
             }
@@ -193,17 +198,17 @@ pgLine_FromObjectFastcall(PyObject *const *args, Py_ssize_t nargs,
         return pgLine_FromObject(args[0], out);
     }
     else if (nargs == 2) {
-        if (!pg_TwoDoublesFromObj(args[0], &(out->x1), &(out->y1)) ||
-            !pg_TwoDoublesFromObj(args[1], &(out->x2), &(out->y2))) {
+        if (!pg_TwoFloatsFromObj(args[0], &(out->x1), &(out->y1)) ||
+            !pg_TwoFloatsFromObj(args[1], &(out->x2), &(out->y2))) {
             return 0;
         }
         return 1;
     }
     else if (nargs == 4) {
-        if (!pg_DoubleFromObj(args[0], &(out->x1)) ||
-            !pg_DoubleFromObj(args[1], &(out->y1)) ||
-            !pg_DoubleFromObj(args[2], &(out->x2)) ||
-            !pg_DoubleFromObj(args[3], &(out->y2))) {
+        if (!pg_FloatFromObj(args[0], &(out->x1)) ||
+            !pg_FloatFromObj(args[1], &(out->y1)) ||
+            !pg_FloatFromObj(args[2], &(out->x2)) ||
+            !pg_FloatFromObj(args[3], &(out->y2))) {
             return 0;
         }
         return 1;
@@ -218,7 +223,7 @@ pgLine_New(pgLineBase *l)
 }
 
 static PyObject *
-pgLine_New4(double x1, double y1, double x2, double y2)
+pgLine_New4(float x1, float y1, float x2, float y2)
 {
     return _pg_line_subtype_new4(&pgLine_Type, x1, y1, x2, y2);
 }
@@ -253,8 +258,8 @@ pg_line_raycast(pgLineObject *self, PyObject *const *args, Py_ssize_t nargs)
     farr = PySequence_Fast_ITEMS(args[0]);
 
     // find the best t
-    double record = DBL_MAX;
-    double temp_t = 0;
+    float record = FLT_MAX;
+    float temp_t = 0;
 
     for (loop = 0; loop < length; loop++) {
         if (pgCircle_Check(farr[loop])) {
@@ -285,7 +290,7 @@ pg_line_raycast(pgLineObject *self, PyObject *const *args, Py_ssize_t nargs)
         }
     }
 
-    if (record == DBL_MAX) {
+    if (record == FLT_MAX) {
         Py_RETURN_NONE;
     }
     // construct the return with this formula: A+tB
@@ -312,16 +317,16 @@ static PyObject *
 pg_line_collidepoint(pgLineObject *self, PyObject *const *args,
                      Py_ssize_t nargs)
 {
-    double Cx = 0, Cy = 0;
+    float Cx = 0, Cy = 0;
 
     if (nargs == 1) {
-        if (!pg_TwoDoublesFromObj(args[0], &Cx, &Cy)) {
+        if (!pg_TwoFloatsFromObj(args[0], &Cx, &Cy)) {
             goto error;
         }
     }
     else if (nargs == 2) {
-        if (!pg_DoubleFromObj(args[0], &Cx) ||
-            !pg_DoubleFromObj(args[1], &Cy)) {
+        if (!pg_FloatFromObj(args[0], &Cx) ||
+            !pg_FloatFromObj(args[1], &Cy)) {
             goto error;
         }
     }
@@ -353,10 +358,10 @@ pg_line_collidecircle(pgLineObject *self, PyObject *const *args,
 static PyObject *
 pg_line_as_rect(pgLineObject *self, PyObject *_null)
 {
-    double Ax = self->line.x1;
-    double Ay = self->line.y1;
-    double Bx = self->line.x2;
-    double By = self->line.y2;
+    float Ax = self->line.x1;
+    float Ay = self->line.y1;
+    float Bx = self->line.x2;
+    float By = self->line.y2;
 
     int rect_x = (int)floor(MIN(Ax, Bx));
     int rect_y = (int)floor(MIN(Ay, By));
@@ -399,7 +404,7 @@ pg_line_seq_length(PyObject *_self)
 static PyObject *
 pg_line_item(pgLineObject *self, Py_ssize_t i)
 {
-    double *data = (double *)&self->line;
+    float *data = (float *)&self->line;
 
     if (i < 0 || i > 3) {
         if (i > -5 && i < 0) {
@@ -409,14 +414,14 @@ pg_line_item(pgLineObject *self, Py_ssize_t i)
             return RAISE(PyExc_IndexError, "Invalid line Index");
         }
     }
-    return PyFloat_FromDouble(data[i]);
+    return PyFloat_FromFloat(data[i]);
 }
 
 static int
 pg_line_ass_item(pgLineObject *self, Py_ssize_t i, PyObject *v)
 {
-    double val = 0;
-    double *data = (double *)&self->line;
+    float val = 0;
+    float *data = (float *)&self->line;
 
     if (i < 0 || i > 3) {
         if (i > -5 && i < 0) {
@@ -427,7 +432,7 @@ pg_line_ass_item(pgLineObject *self, Py_ssize_t i, PyObject *v)
             return -1;
         }
     }
-    if (!pg_DoubleFromObj(v, &val)) {
+    if (!pg_FloatFromObj(v, &val)) {
         PyErr_SetString(PyExc_TypeError, "Must assign numeric values");
         return -1;
     }
@@ -439,7 +444,7 @@ static int
 pg_line_contains_seq(pgLineObject *self, PyObject *arg)
 {
     if (PyNumber_Check(arg)) {
-        double coord = PyFloat_AsDouble(arg);
+        float coord = PyFloat_AsFloat(arg);
         return coord == self->line.x1 || coord == self->line.y1 ||
                coord == self->line.x2 || coord == self->line.y1;
     }
@@ -465,7 +470,7 @@ static PySequenceMethods pg_line_as_sequence = {
 static PyObject *
 pg_line_subscript(pgLineObject *self, PyObject *op)
 {
-    double *data = (double *)&self->line;
+    float *data = (float *)&self->line;
 
     if (PyIndex_Check(op)) {
         PyObject *index = PyNumber_Index(op);
@@ -485,10 +490,10 @@ pg_line_subscript(pgLineObject *self, PyObject *op)
             return NULL;
         }
 
-        PyList_SET_ITEM(lst, 0, PyFloat_FromDouble(data[0]));
-        PyList_SET_ITEM(lst, 1, PyFloat_FromDouble(data[1]));
-        PyList_SET_ITEM(lst, 2, PyFloat_FromDouble(data[2]));
-        PyList_SET_ITEM(lst, 3, PyFloat_FromDouble(data[3]));
+        PyList_SET_ITEM(lst, 0, PyFloat_FromFloat(data[0]));
+        PyList_SET_ITEM(lst, 1, PyFloat_FromFloat(data[1]));
+        PyList_SET_ITEM(lst, 2, PyFloat_FromFloat(data[2]));
+        PyList_SET_ITEM(lst, 3, PyFloat_FromFloat(data[3]));
 
         return lst;
     }
@@ -510,7 +515,7 @@ pg_line_subscript(pgLineObject *self, PyObject *op)
             return NULL;
         }
         for (i = 0; i < slicelen; ++i) {
-            n = PyFloat_FromDouble(data[start + (step * i)]);
+            n = PyFloat_FromFloat(data[start + (step * i)]);
             if (n == NULL) {
                 Py_DECREF(slice);
                 return NULL;
@@ -539,9 +544,9 @@ pg_line_ass_subscript(pgLineObject *self, PyObject *op, PyObject *value)
         return pg_line_ass_item(self, i, value);
     }
     else if (op == Py_Ellipsis) {
-        double val = 0;
+        float val = 0;
 
-        if (pg_DoubleFromObj(value, &val)) {
+        if (pg_FloatFromObj(value, &val)) {
             self->line.x1 = val;
             self->line.y1 = val;
             self->line.x2 = val;
@@ -557,7 +562,7 @@ pg_line_ass_subscript(pgLineObject *self, PyObject *op, PyObject *value)
         }
         else if (PySequence_Check(value)) {
             PyObject *item;
-            double values[4];
+            float values[4];
             Py_ssize_t i;
 
             if (PySequence_Size(value) != 4) {
@@ -566,10 +571,10 @@ pg_line_ass_subscript(pgLineObject *self, PyObject *op, PyObject *value)
             }
             for (i = 0; i < 4; ++i) {
                 item = PySequence_ITEM(value, i);
-                if (!pg_DoubleFromObj(item, values + i)) {
+                if (!pg_FloatFromObj(item, values + i)) {
                     PyErr_Format(PyExc_TypeError,
                                  "Expected a number between %lf and %lf",
-                                 DBL_MIN, DBL_MAX);
+                                 FLT_MIN, FLT_MAX);
                 }
             }
             self->line.x1 = values[0];
@@ -583,26 +588,26 @@ pg_line_ass_subscript(pgLineObject *self, PyObject *op, PyObject *value)
         }
     }
     else if (PySlice_Check(op)) {
-        double *data = (double *)&self->line;
+        float *data = (float *)&self->line;
         Py_ssize_t start;
         Py_ssize_t stop;
         Py_ssize_t step;
         Py_ssize_t slicelen;
-        double val = 0;
+        float val = 0;
         Py_ssize_t i;
 
         if (PySlice_GetIndicesEx(op, 4, &start, &stop, &step, &slicelen)) {
             return -1;
         }
 
-        if (pg_DoubleFromObj(value, &val)) {
+        if (pg_FloatFromObj(value, &val)) {
             for (i = 0; i < slicelen; ++i) {
                 data[start + step * i] = val;
             }
         }
         else if (PySequence_Check(value)) {
             PyObject *item;
-            double values[4];
+            float values[4];
             Py_ssize_t size = PySequence_Size(value);
 
             if (size != slicelen) {
@@ -612,10 +617,10 @@ pg_line_ass_subscript(pgLineObject *self, PyObject *op, PyObject *value)
             }
             for (i = 0; i < slicelen; ++i) {
                 item = PySequence_ITEM(value, i);
-                if (!pg_DoubleFromObj(item, values + i)) {
+                if (!pg_FloatFromObj(item, values + i)) {
                     PyErr_Format(PyExc_TypeError,
                                  "Expected a number between %lf and %lf",
-                                 DBL_MIN, DBL_MAX);
+                                 FLT_MIN, FLT_MAX);
                 }
             }
             for (i = 0; i < slicelen; ++i) {
@@ -657,9 +662,9 @@ pg_line_repr(pgLineObject *self)
 {
     // dont comments on it (-_-)
     return PyUnicode_FromFormat(
-        "pygame.Line(%S, %S, %S, %S)", PyFloat_FromDouble(self->line.x1),
-        PyFloat_FromDouble(self->line.y1), PyFloat_FromDouble(self->line.x2),
-        PyFloat_FromDouble(self->line.y2));
+        "pygame.Line(%S, %S, %S, %S)", PyFloat_FromFloat(self->line.x1),
+        PyFloat_FromFloat(self->line.y1), PyFloat_FromFloat(self->line.x2),
+        PyFloat_FromFloat(self->line.y2));
 }
 
 static PyObject *
@@ -672,7 +677,7 @@ static PyObject *
 pg_line_richcompare(PyObject *o1, PyObject *o2, int opid)
 {
     pgLineBase o1line, o2line;
-    double length1, length2;
+    float length1, length2;
 
     if (!pgLine_FromObject(o1, &o1line) || !pgLine_FromObject(o2, &o2line)) {
         goto Unimplemented;
@@ -707,13 +712,13 @@ static PyObject *
 pg_line_iterator(pgLineObject *self)
 {
     Py_ssize_t i;
-    double *data = (double *)&self->line;
+    float *data = (float *)&self->line;
     PyObject *iter, *tup = PyTuple_New(4);
     if (!tup) {
         return NULL;
     }
     for (i = 0; i < 4; i++) {
-        PyObject *val = PyFloat_FromDouble(data[i]);
+        PyObject *val = PyFloat_FromFloat(data[i]);
         if (!val) {
             Py_DECREF(tup);
             return NULL;
@@ -729,14 +734,14 @@ pg_line_iterator(pgLineObject *self)
 #define __LINE_GETSET_NAME(name)                                          \
     static PyObject *pg_line_get##name(pgLineObject *self, void *closure) \
     {                                                                     \
-        return PyFloat_FromDouble(self->line.name);                       \
+        return PyFloat_FromFloat(self->line.name);                        \
     }                                                                     \
     static int pg_line_set##name(pgLineObject *self, PyObject *value,     \
                                  void *closure)                           \
     {                                                                     \
-        double val;                                                       \
+        float val;                                                        \
         DEL_ATTR_NOT_SUPPORTED_CHECK_NO_NAME(value);                      \
-        if (pg_DoubleFromObj(value, &val)) {                              \
+        if (pg_FloatFromObj(value, &val)) {                               \
             self->line.name = val;                                        \
             return 0;                                                     \
         }                                                                 \
@@ -758,17 +763,17 @@ pg_line_geta(pgLineObject *self, void *closure)
     if (!tup) {
         return PyErr_NoMemory();
     }
-    PyTuple_SET_ITEM(tup, 0, PyFloat_FromDouble(self->line.x1));
-    PyTuple_SET_ITEM(tup, 1, PyFloat_FromDouble(self->line.y1));
+    PyTuple_SET_ITEM(tup, 0, PyFloat_FromFloat(self->line.x1));
+    PyTuple_SET_ITEM(tup, 1, PyFloat_FromFloat(self->line.y1));
     return tup;
 }
 
 static int
 pg_line_seta(pgLineObject *self, PyObject *value, void *closure)
 {
-    double x, y;
+    float x, y;
     DEL_ATTR_NOT_SUPPORTED_CHECK_NO_NAME(value);
-    if (pg_TwoDoublesFromObj(value, &x, &y)) {
+    if (pg_TwoFloatsFromObj(value, &x, &y)) {
         self->line.x1 = x;
         self->line.y1 = y;
         return 0;
@@ -784,17 +789,17 @@ pg_line_getb(pgLineObject *self, void *closure)
     if (!tup) {
         return PyErr_NoMemory();
     }
-    PyTuple_SET_ITEM(tup, 0, PyFloat_FromDouble(self->line.x2));
-    PyTuple_SET_ITEM(tup, 1, PyFloat_FromDouble(self->line.y2));
+    PyTuple_SET_ITEM(tup, 0, PyFloat_FromFloat(self->line.x2));
+    PyTuple_SET_ITEM(tup, 1, PyFloat_FromFloat(self->line.y2));
     return tup;
 }
 
 static int
 pg_line_setb(pgLineObject *self, PyObject *value, void *closure)
 {
-    double x, y;
+    float x, y;
     DEL_ATTR_NOT_SUPPORTED_CHECK_NO_NAME(value);
-    if (pg_TwoDoublesFromObj(value, &x, &y)) {
+    if (pg_TwoFloatsFromObj(value, &x, &y)) {
         self->line.x2 = x;
         self->line.y2 = y;
         return 0;

--- a/src_c/line.c
+++ b/src_c/line.c
@@ -11,12 +11,18 @@
 #define PyFloat_FromFloat(x) \
     (PyFloat_FromDouble((double)(round((x)*10000000) / 10000000)))
 #endif
+#ifndef PyFloat_AsFloat
+#define PyFloat_AsFloat(x) ((float)PyFloat_AsDouble(x))
+#endif
+#ifndef PyFloat_ASFLOAT
+#define PyFloat_ASFLOAT(x) ((float)PyFloat_AS_DOUBLE(x))
+#endif
 
 static float
 pgLine_Length(pgLineBase line)
 {
-    return sqrt((line.x2 - line.x1) * (line.x2 - line.x1) +
-                (line.y2 - line.y1) * (line.y2 - line.y1));
+    return sqrtf((line.x2 - line.x1) * (line.x2 - line.x1) +
+                 (line.y2 - line.y1) * (line.y2 - line.y1));
 }
 static float
 pgLine_LengthSquared(pgLineBase line)

--- a/src_c/line.c
+++ b/src_c/line.c
@@ -8,8 +8,7 @@
 #include <math.h>
 
 #ifndef PyFloat_FromFloat
-#define PyFloat_FromFloat(x) \
-    (PyFloat_FromDouble((double)(round((x)*10000000) / 10000000)))
+#define PyFloat_FromFloat(x) (PyFloat_FromDouble((double)(x)))
 #endif
 #ifndef PyFloat_AsFloat
 #define PyFloat_AsFloat(x) ((float)PyFloat_AsDouble(x))


### PR DESCRIPTION
As a first implementation, we decided to use double as number precision for positions and data for shapes. This turned out to be unnecessary and weird, as game developement usually implements stuff with floats. Using floats will enable us to write more efficient functions, both normal and SIMD functions, which will benefit a lot from this change.