### PR TITLE
Add line support to collideswith

### DIFF
--- a/benchmarks/GEOMETRY_circle_benchmark.py
+++ b/benchmarks/GEOMETRY_circle_benchmark.py
@@ -1,6 +1,6 @@
 from pygame import Rect
 from benchmark_utils import TestSuite
-from geometry import Circle
+from geometry import Circle, Line
 
 r1 = Rect(0, 0, 10, 10)
 r2 = Rect(10, 10, 4, 4)
@@ -10,6 +10,9 @@ c1 = Circle(10, 10, 10)
 c2 = Circle(20, 5, 15)
 c3 = Circle(50, 50, 15)
 c4 = Circle(10, 10, 15)
+
+l1 = Line(0, 0, 10, 10)
+l2 = Line(0, 0, 10, -10)
 
 p1 = (10, 10)
 p2 = (1000, 1000)
@@ -25,6 +28,8 @@ GLOB = {
     "c2": c2,
     "c3": c3,
     "c4": c4,
+    "l1": l1,
+    "l2": l2,
     "p1": p1,
     "p2": p2,
     "p3": p3,
@@ -113,6 +118,16 @@ CP_collision_tests = [
     ("Non colliding 2 float", "c1.collidepoint(1000.0, 1000.0)"),
 ]
 
+CL_collision_tests = [
+    ("Colliding", "c1.collideline(l1)"),
+    ("Non colliding", "c1.collideline(l2)"),
+    ("Colliding 1 int", "c1.collideline((0, 0, 10, 10))"),
+    ("Non colliding 1 int", "c1.collideline((0, 0, 10, -10))"),
+    ("Colliding 1 float", "c1.collideline((0.0, 0.0, 10.0, 10.0))"),
+    ("Non colliding 1 float", "c1.collideline((0.0, 0.0, 10.0, -10.0))"),
+]
+
+
 CS_collision_tests = [
     ("RECT colliding", "c1.collideswith(r1)"),
     ("RECT non colliding", "c1.collideswith(r2)"),
@@ -120,6 +135,8 @@ CS_collision_tests = [
     ("CIRCLE non colliding", "c1.collideswith(c2)"),
     ("POINT colliding", "c1.collideswith(p1)"),
     ("POINT non colliding", "c1.collideswith(p2)"),
+    ("LINE colliding", "c1.collideswith(l1)"),
+    ("LINE non colliding", "c1.collideswith(l2)"),
 ]
 
 # === Test Suites ===
@@ -131,11 +148,12 @@ GROUPS = [
     ("Copy", copy_tests),
     ("Conversion", conversion_tests),
     ("Update", update_tests),
-    # ("Move", move_tests),
+    ("Move", move_tests),
     ("Collision: Circle-Circle ", CC_collision_tests),
     ("Collision: Circle-Rect", CR_collision_tests),
     ("Collision: Circle-Point", CP_collision_tests),
+    ("Collision: Circle-Line", CL_collision_tests),
     ("Collision: Circle-Shape", CS_collision_tests),
 ]
 
-TestSuite("Geometry Module - Circle", GROUPS, GLOB).run_suite()
+TestSuite("Geometry Module - Circle", GROUPS, GLOB, repeat_num=10).run_suite()

--- a/benchmarks/GEOMETRY_circle_benchmark.py
+++ b/benchmarks/GEOMETRY_circle_benchmark.py
@@ -156,4 +156,4 @@ GROUPS = [
     ("Collision: Circle-Shape", CS_collision_tests),
 ]
 
-TestSuite("Geometry Module - Circle", GROUPS, GLOB, repeat_num=10).run_suite()
+TestSuite("Geometry Module - Circle", GROUPS, GLOB).run_suite()

--- a/src_c/circle.c
+++ b/src_c/circle.c
@@ -313,15 +313,23 @@ pg_circle_collideswith(pgCircleObject *self, PyObject *arg)
     else if (pgRect_Check(arg)) {
         result = pgCollision_RectCircle(&pgRect_AsRect(arg), &self->circle);
     }
+    else if (pgLine_Check(arg)) {
+        result = pgCollision_LineCircle(&pgLine_AsLine(arg), &self->circle);
+    }
     else if (PySequence_Check(arg)) {
         double x, y;
         if (!pg_TwoDoublesFromObj(arg, &x, &y)) {
             return RAISE(PyExc_TypeError,
-                         "Invalid arguments, must be a sequence of 2 numbers");
+                         "Invalid point argument, must be a sequence of 2 numbers");
         }
-        return PyBool_FromLong(
-            pgCollision_CirclePoint(&pgCircle_AsCircle(self), x, y));
+        result = pgCollision_CirclePoint(&self->circle, x, y);
     }
+    else {
+        return RAISE(PyExc_TypeError,
+                     "Invalid shape argument, must be a CircleType, RectType, "
+                     "LineType or a sequence of 2 numbers");
+    }
+
     return PyBool_FromLong(result);
 }
 

--- a/test/test_circle.py
+++ b/test/test_circle.py
@@ -8,6 +8,9 @@ from pygame import Rect
 
 from geometry import Circle, Line
 
+E_T = "Expected True, "
+E_F = "Expected False, "
+
 
 class CircleTypeTest(unittest.TestCase):
     def testConstruction_invalid_type(self):
@@ -568,6 +571,59 @@ class CircleTypeTest(unittest.TestCase):
 
         # barely colliding single
         self.assertTrue(c.colliderect(0, 4.9999999999999, 4, 4), msgt)
+
+    def test_collideswith_argtype(self):
+        """tests if the function correctly handles incorrect types as parameters"""
+        invalid_types = (None, [], "1", (1,), Vector3(1, 1, 1), 1)
+
+        c = Circle(10, 10, 4)
+
+        for value in invalid_types:
+            with self.assertRaises(TypeError):
+                c.collideswith(value)
+
+    def test_collideswith_argnum(self):
+        c = Circle(10, 10, 4)
+        args = [tuple(range(x)) for x in range(2, 4)]
+
+        # no params
+        with self.assertRaises(TypeError):
+            c.collideswith()
+
+        # too many params
+        for arg in args:
+            with self.assertRaises(TypeError):
+                c.collideswith(*arg)
+
+    def test_collideswith(self):
+        """Ensures the collideswith function correctly registers collisions with circles, lines, rects and points"""
+        c = Circle(0, 0, 5)
+
+        # circle
+        c2 = Circle(0, 10, 15)
+        c3 = Circle(100, 100, 1)
+        self.assertTrue(c.collideswith(c2), E_T + "circles should collide here")
+        self.assertFalse(c.collideswith(c3), E_F + "circles should not collide here")
+
+        # line
+        l = Line(0, 0, 10, 10)
+        l2 = Line(50, 0, 50, 10)
+        self.assertTrue(c.collideswith(l), E_T + "line should collide here")
+        self.assertFalse(c.collideswith(l2), E_F + "line should not collide here")
+
+        # rect
+        r = Rect(0, 0, 10, 10)
+        r2 = Rect(50, 0, 10, 10)
+        self.assertTrue(c.collideswith(r), E_T + "rect should collide here")
+        self.assertFalse(c.collideswith(r2), E_F + "rect should not collide here")
+
+        # point
+        p = (0, 0)
+        p2 = (50, 0)
+        self.assertTrue(c.collideswith(p), "Expected True, point should collide here")
+        self.assertFalse(
+            c.collideswith(p2), "Expected False, point should not collide here"
+        )
 
     def test_as_rect_invalid_args(self):
 

--- a/test/test_circle.py
+++ b/test/test_circle.py
@@ -620,10 +620,8 @@ class CircleTypeTest(unittest.TestCase):
         # point
         p = (0, 0)
         p2 = (50, 0)
-        self.assertTrue(c.collideswith(p), "Expected True, point should collide here")
-        self.assertFalse(
-            c.collideswith(p2), "Expected False, point should not collide here"
-        )
+        self.assertTrue(c.collideswith(p), E_T + "point should collide here")
+        self.assertFalse(c.collideswith(p2), E_F + "point should not collide here")
 
     def test_as_rect_invalid_args(self):
 


### PR DESCRIPTION
The `circle.collideswith()` function didn't have support for Circle-Line collision and had a wrong behaviour for unsupported types, so i added support for the Line type and corrected the wrong behaviour. I also added more benchmarks and the missing collideswith() unittests.